### PR TITLE
Font-family was added.

### DIFF
--- a/apps/editor/src/styles.less
+++ b/apps/editor/src/styles.less
@@ -1,1 +1,3 @@
-/* You can add global styles to this file, and also import other style files */
+body {
+    font-family: "proxima-nova-soft", "Proxima Nova Soft", Helvetica, Arial, sans-serif;
+  }


### PR DESCRIPTION
**Problem:**
There is default serif font in use in Editor for now.

**Solution:**
In the styles.less file was added font-family css-property which was taken from https://github.com/groupdocs-total/GroupDocs.Total-Angular/blob/master/apps/viewer/src/styles.less#L9, i didn't add other lines, because i'm not sure that this should be done (should be done in this commit).

**Tests:**
![image](https://user-images.githubusercontent.com/17431807/60657753-81985480-9e5a-11e9-88db-192e72041bbb.png)