### PR TITLE
The main Editor logo was replaced to the correct one.

### DIFF
--- a/apps/editor/src/app/editor-app.component.html
+++ b/apps/editor/src/app/editor-app.component.html
@@ -70,7 +70,7 @@
     </gd-document>
 
   </div>
-  <gd-init-state [icon]="'eye'" [text]="''" *ngIf="!file"></gd-init-state>
+  <gd-init-state [icon]="'pen'" [text]="''" *ngIf="!file"></gd-init-state>
   <gd-browse-files-modal
     (urlForUpload)="upload($event)"
     [files]="files"


### PR DESCRIPTION
**Problem:**
Editor app component has hard-coded incorrect icon inherited from the Viewer app component.

**Solution:**
Icon code was changed to the correct one.

**Tests:**
![image](https://user-images.githubusercontent.com/17431807/60670264-ecf11f00-9e78-11e9-816a-ed53426fc4f1.png)
