### PR TITLE
Fix min page height.

### DIFF
--- a/apps/editor/src/app/editor-app.component.ts
+++ b/apps/editor/src/app/editor-app.component.ts
@@ -258,6 +258,8 @@ export class EditorAppComponent {
     this.file = file;
     if (this.file && this.file.pages[0]) {
       this.file.pages[0].editable = true;
+      this.file.pages[0].width = 595;
+      this.file.pages[0].height = 842;
       this.textBackup = this.file.pages[0].data;
     }
     this.formatDisabled = !this.file;


### PR DESCRIPTION
**Problem:**
Page height of new document after saving must be the same as before.
Now document height is collapsed.

**Solution:**
Assigning the default width and height was added.

**Screenshots:**
![page-size-after-save](https://user-images.githubusercontent.com/17431807/60882746-31056a80-a251-11e9-9852-8ed8e4a0495a.gif)