### PR TITLE
Added work-around for correct handling not zero-based pages id.

### DIFF
--- a/libs/comparison/src/lib/comparison-app.component.ts
+++ b/libs/comparison/src/lib/comparison-app.component.ts
@@ -215,9 +215,12 @@ export class ComparisonAppComponent {
     this._comparisonService.compare(arr).subscribe((result: CompareResult) => {
       this.result = result;
 
+      const isZeroBasedPageId = this.result.changes.find((change) => change.pageInfo.id === 0);
+
       this.result.changes.forEach( (change) => {
         change.id = this.generateRandomInteger();
-        const zeroBasedId = change.pageInfo.id;
+        const zeroBasedId = isZeroBasedPageId ? change.pageInfo.id : change.pageInfo.id - 1;
+        change.pageInfo.id = isZeroBasedPageId ? change.pageInfo.id : change.pageInfo.id - 1;
         if(!this.result.pages[zeroBasedId].changes){
           this.result.pages[zeroBasedId].changes = [];
         }


### PR DESCRIPTION
**How it looks with WA:**
![comparing_pdf_zero_based_pages_0](https://user-images.githubusercontent.com/17431807/64336935-d4bb8e80-cfe6-11e9-86ff-9d37880229f2.gif)

**For:** groupdocs-comparison/GroupDocs.Comparison-for-.NET-WebForms#25