### PR TITLE
Moving scrollable directive on a new place for editor/comparison.

### DIFF
--- a/libs/comparison/src/lib/comparison-app.component.html
+++ b/libs/comparison/src/lib/comparison-app.component.html
@@ -83,7 +83,8 @@
           [mode]="false"
           [preloadPageCount]="comparisonConfig?.preloadResultPageCount"
           gdRenderPrint
-          [htmlMode]="false">
+          [htmlMode]="false"
+          gdScrollable>
         </gd-result-document>
       </div>
     </div>

--- a/libs/comparison/src/lib/result-document/result-document.component.html
+++ b/libs/comparison/src/lib/result-document/result-document.component.html
@@ -1,5 +1,5 @@
 <div class="wait" *ngIf="wait">Please wait...</div>
-<div id="document" class="document" gdScrollable>
+<div id="document" class="document">
   <div class="panzoom">
     <div [ngClass]="'page'" *ngFor="let page of file?.pages"
          [style.height]="getDimensionWithUnit(page.height)"

--- a/libs/comparison/src/lib/result-document/result-document.component.less
+++ b/libs/comparison/src/lib/result-document/result-document.component.less
@@ -1,11 +1,13 @@
 @import "./../../../../common-components/src/styles/variables.less";
 
+:host {
+  overflow: scroll;
+}
+
 .document {
   background-color: #e7e7e7;
   width: 100%;
   height: 100%;
-  overflow-x: hidden;
-  overflow-y: auto !important;
   transition: all 0.4s;
   padding: 0px;
   margin: 0px;

--- a/libs/editor/src/lib/editor-app.component.html
+++ b/libs/editor/src/lib/editor-app.component.html
@@ -67,7 +67,7 @@
                    (selectedColor)="selectColor($event)"></gd-color-picker>
   <div class="doc-panel" *ngIf="file">
     <gd-document class="gd-document" *ngIf="file" [file]="file" [mode]="true" [htmlMode]="true"
-                 [preloadPageCount]="0" gdFormatting gdRenderPrint>
+                 [preloadPageCount]="0" gdFormatting gdRenderPrint gdScrollable>
     </gd-document>
   </div>
   <gd-init-state [icon]="'pen-square'" [text]="'Drop file here to upload'" *ngIf="!file" (fileDropped)="fileDropped($event)">


### PR DESCRIPTION
**Tests:**
One manual test was performed - moving between the highlighted changes in the comparison app.
Any cases of using scrollable directive in the editor app were not found yet.