### PR TITLE
Removing name-spaces added by FF.

### DIFF
--- a/libs/viewer/src/lib/excel-page.service.ts
+++ b/libs/viewer/src/lib/excel-page.service.ts
@@ -20,7 +20,9 @@ export class ExcelPageService {
     const newTable = this.createHeader(numCellsInFirstRow, table);
     doc.querySelector('table').replaceWith(newTable);
 
-    return new XMLSerializer().serializeToString(doc);
+    const resultData = new XMLSerializer().serializeToString(doc)
+    // work-around for FF which is adds a0 namespace during serialization
+    return resultData.replace(/a0:/g,"").replace(/:a0/g,"");
   }
 
   createHeader(numCols, table){


### PR DESCRIPTION
**Problem:**
![bug_in_ff_before](https://user-images.githubusercontent.com/17431807/70269840-3b9e3e80-17b4-11ea-9c7b-82cc389dff1e.png)

**Solution:**
FF adds `a0` namespace somewhere in the engine, and it looks like https://hg.mozilla.org/mozilla-central/rev/3ecc407c0cc8705ba7b60fbbe8964e794c0a5651#l54.241.
As a work-around was added the line with removal of this namespace.

**Screenshots:**
![image](https://user-images.githubusercontent.com/17431807/70270059-9afc4e80-17b4-11ea-876f-29f805ade7d8.png)