### PR TITLE
Required changes for correct save on updated Editor API.

### DIFF
--- a/libs/editor/src/lib/editor-app.component.less
+++ b/libs/editor/src/lib/editor-app.component.less
@@ -58,7 +58,6 @@
 }
 
 ::ng-deep .gd-wrapper {
-  padding: 19px 96px;
   -webkit-user-select: text;  /* Chrome all / Safari all */
   -moz-user-select: text;     /* Firefox all */
   -ms-user-select: text;      /* IE 10+ */
@@ -167,6 +166,9 @@
 }
 
 ::ng-deep .documentMainContent {
+  .section {
+    margin: 0px !important;
+  }
   >div {
     display: flex;
     flex-direction: column;

--- a/libs/editor/src/lib/editor-app.component.ts
+++ b/libs/editor/src/lib/editor-app.component.ts
@@ -531,8 +531,7 @@ export class EditorAppComponent implements OnInit, AfterViewInit  {
 
   getPageWithRootTags(data) {
     let resultData = "<html><head>" + data + "</body></html>";
-    resultData = resultData.replace('<div class="documentMainContent">', '<body><div class="documentMainContent">');
-    resultData = resultData.replace('<body><div class="documentMainContent">', '</head><body><div class="documentMainContent">');
+    resultData = resultData.replace('<div class="documentMainContent">', '</head><body><div class="documentMainContent">');
     return resultData;
   }
 

--- a/libs/editor/src/lib/editor-app.component.ts
+++ b/libs/editor/src/lib/editor-app.component.ts
@@ -518,12 +518,22 @@ export class EditorAppComponent implements OnInit, AfterViewInit  {
  saveFile(credentials: FileCredentials) {
     if (!this.file || !this.file.pages)
       return;
+      
+    this.textBackup = this.getPageWithRootTags(this.textBackup);
+
     const saveFile = new SaveFile(credentials.guid, credentials.password, this.textBackup);
     this._editorService.save(saveFile).subscribe((loadFile: FileDescription) => {
       this.loadFile(loadFile);
       this.credentials = new FileCredentials(loadFile.guid, credentials.password);
       this._modalService.open(CommonModals.OperationSuccess);
     });
+  }
+
+  getPageWithRootTags(data) {
+    let resultData = "<html><head>" + data + "</body></html>";
+    resultData = resultData.replace('<div class="documentMainContent">', '<body><div class="documentMainContent">');
+    resultData = resultData.replace('<body><div class="documentMainContent">', '</head><body><div class="documentMainContent">');
+    return resultData;
   }
 
   printFile() {


### PR DESCRIPTION
**Problem:**
1. We have problem with Footer/Header presentation before and after saving changes.
2. We have redundant paddings/margins during using newest Editor API.

**Solution:**
Were made changes that are needed for correct presentation (removed padding/margin) and saving (adding root tags on client-side) edited documents in the Editor app on latest API version. Related PR for back-end: https://github.com/groupdocs-total/GroupDocs.Total-for-NET-MVC/pull/81.

**Screenshots:**
<details>
  <summary>Take a look</summary>

![total_mvc_footer_save](https://user-images.githubusercontent.com/17431807/75879724-eca48b80-5e2c-11ea-863e-3fbb9a581d23.gif)

</details>