### PR TITLE
Changes/improvements for the new Conversion API.

### DIFF
--- a/apps/total-angular-e2e/src/integration/conversion.spec.ts
+++ b/apps/total-angular-e2e/src/integration/conversion.spec.ts
@@ -101,9 +101,9 @@ describe('Conversion', () => {
     cy.get('#tools > gd-button:nth-child(1)').click();
     cy.get('#gd-modal-filebrowser > div.list-files-body > div:nth-child(3) > div.file-format-select > gd-drop-down').click();
     cy.get('#gd-modal-filebrowser > div.list-files-body > div:nth-child(3) > div.file-format-select > gd-drop-down > div > gd-drop-down-items > div > gd-drop-down-item:nth-child(1)').click();
-    cy.get('#gd-convert-queue > div:nth-child(2) > gd-conversion-item').should('exist');
-    cy.get('#gd-convert-queue > div:nth-child(2) > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div').should('contain', 'TestWord.xls');
-    cy.get('#gd-convert-queue > div:nth-child(2) > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div > div').should('have.text', 'Microsoft Excel');
+    cy.get('#gd-convert-queue > div.gd-queue-body > div > gd-conversion-item > div').should('exist');
+    cy.get('#gd-convert-queue > div.gd-queue-body > div > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div').should('contain', 'TestWord.xls');
+    cy.get('#gd-convert-queue > div.gd-queue-body > div > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div > div').should('have.text', 'Microsoft Excel');
   });
 
   it('should show change convert icon to download after successful single item converting', () => {
@@ -111,9 +111,9 @@ describe('Conversion', () => {
     cy.get('#tools > gd-button:nth-child(1)').click();
     cy.get('#gd-modal-filebrowser > div.list-files-body > div:nth-child(3) > div.file-format-select > gd-drop-down').click();
     cy.get('#gd-modal-filebrowser > div.list-files-body > div:nth-child(3) > div.file-format-select > gd-drop-down > div > gd-drop-down-items > div > gd-drop-down-item:nth-child(1)').click();
-    cy.get('#gd-convert-queue > div:nth-child(2) > gd-conversion-item > div > div:nth-child(6) > fa-icon').click();
-    cy.get('#gd-convert-queue > div:nth-child(2) > gd-conversion-item > div > div.gd-convert-status > fa-icon.gd-conversion-complete.ng-fa-icon').should('be.visible');
-    cy.get('#gd-convert-queue > div:nth-child(2) > gd-conversion-item > div > div.gd-download-single').should('be.visible');
+    cy.get('#gd-convert-queue > div.gd-queue-body > div > gd-conversion-item > div > div:nth-child(6) > fa-icon').click();
+    cy.get('#gd-convert-queue > div.gd-queue-body > div > gd-conversion-item > div > div.gd-convert-status > fa-icon.gd-conversion-complete.ng-fa-icon').should('be.visible');
+    cy.get('#gd-convert-queue > div.gd-queue-body > div > gd-conversion-item > div > div.gd-download-single').should('be.visible');
   });
 
   it('should open drop-down with formats when selected multiple files in dialog and display formats', () => {
@@ -137,10 +137,10 @@ describe('Conversion', () => {
     cy.get('#gd-convert-queue gd-conversion-item').its('length').should('eq', 2);
     cy.get('.gd-modal-title').should('have.text', 'Imposible conversions');
     cy.get('.gd-modal-close > span').click();
-    cy.get('#gd-convert-queue > div:nth-child(2) > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div').should('contain', 'TestWord.html');
-    cy.get('#gd-convert-queue > div:nth-child(2) > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div > div').should('have.text', 'HyperText Markup Language');
-    cy.get('#gd-convert-queue > div:nth-child(3) > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div').should('contain', 'TestPDF.html');
-    cy.get('#gd-convert-queue > div:nth-child(3) > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div > div').should('have.text', 'HyperText Markup Language');
+    cy.get('#gd-convert-queue > div.gd-queue-body > div:nth-child(1) > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div').should('contain', 'TestWord.html');
+    cy.get('#gd-convert-queue > div.gd-queue-body > div:nth-child(1) > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div > div').should('have.text', 'HyperText Markup Language');
+    cy.get('#gd-convert-queue > div.gd-queue-body > div:nth-child(2) > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div').should('contain', 'TestPDF.html');
+    cy.get('#gd-convert-queue > div.gd-queue-body > div:nth-child(2) > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div > div').should('have.text', 'HyperText Markup Language');
   });
 
   it('should show correct icons for all conversion items after click on convert-all button', () => {
@@ -162,9 +162,9 @@ describe('Conversion', () => {
     cy.get('#gd-modal-filebrowser > div.list-files-body > div:nth-child(3) > div.gd-file-checkbox > input').click();
     cy.get('.context-actions > :nth-child(1) > .drop-down > gd-drop-down-toggle > gd-button > .button').click();
     cy.get('.show > .drop-down > gd-drop-down-items > .drop-down-items > :nth-child(1) > .drop-down-item').click();
-    cy.get('#gd-convert-queue > div:nth-child(2) > gd-conversion-item > div > div.gd-convert-remove > span').click();
+    cy.get('#gd-convert-queue > div.gd-queue-body > div:nth-child(1) > gd-conversion-item > div > div.gd-convert-remove > span').click();
     cy.get('#gd-convert-queue gd-conversion-item').its('length').should('eq', 1);
-    cy.get('#gd-convert-queue > div:nth-child(2) > gd-conversion-item > div > div.gd-convert-remove > span').click();
+    cy.get('#gd-convert-queue > div.gd-queue-body > div:nth-child(1) > gd-conversion-item > div > div.gd-convert-remove > span').click();
     cy.get('body > gd-total > div > gd-conversion > div > gd-init-state > div').should('be.visible');
   });
 
@@ -203,8 +203,8 @@ describe('Conversion', () => {
     cy.get('#gd-modal-filebrowser > div.list-files-body > div:nth-child(3) > div.file-format-select > gd-drop-down').click();
     cy.get('#gd-modal-filebrowser > div.list-files-body > div:nth-child(3) > div.file-format-select > gd-drop-down > div > gd-drop-down-items > div > gd-drop-down-item:nth-child(1)').click();
     cy.get('#gd-convert-queue gd-conversion-item').its('length').should('eq', 1);
-    cy.get('#gd-convert-queue > div:nth-child(2) > gd-conversion-item').should('exist');
-    cy.get('#gd-convert-queue > div:nth-child(2) > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div').should('contain', 'TestWord.xls');
-    cy.get('#gd-convert-queue > div:nth-child(2) > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div > div').should('have.text', 'Microsoft Excel');
+    cy.get('#gd-convert-queue > div.gd-queue-body > div > gd-conversion-item > div').should('exist');
+    cy.get('#gd-convert-queue > div.gd-queue-body > div > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div').should('contain', 'TestWord.xls');
+    cy.get('#gd-convert-queue > div.gd-queue-body > div > gd-conversion-item > div > div.gd-filequeue-name.disabled.gd-destination-file > div > div').should('have.text', 'Microsoft Excel');
   });
 });

--- a/libs/conversion/src/lib/conversion-app.component.ts
+++ b/libs/conversion/src/lib/conversion-app.component.ts
@@ -104,7 +104,8 @@ export class ConversionAppComponent {
   }
 
   convertSingleItem(item) {
-    const workItem = this.conversionItems.find(x => x.guid === item.guid);
+    const workItem = this.conversionItems.find(x => x.guid === item.guid 
+                                                 && x.destinationType == item.destinationType);
     workItem.converting = true;
     this._conversionService.convert(item).subscribe(() => {
       workItem.converting = false;

--- a/libs/conversion/src/lib/conversion-app.component.ts
+++ b/libs/conversion/src/lib/conversion-app.component.ts
@@ -105,7 +105,7 @@ export class ConversionAppComponent {
 
   convertSingleItem(item) {
     const workItem = this.conversionItems.find(x => x.guid === item.guid 
-                                                 && x.destinationType == item.destinationType);
+                                                 && x.destinationType === item.destinationType);
     workItem.converting = true;
     this._conversionService.convert(item).subscribe(() => {
       workItem.converting = false;

--- a/libs/conversion/src/lib/conversion-browse-files-modal/conversion-browse-files-modal.component.html
+++ b/libs/conversion/src/lib/conversion-browse-files-modal/conversion-browse-files-modal.component.html
@@ -10,7 +10,7 @@
             (change)="handleFileInput($event.target.files)">
 
     <div class="select-all">
-      <input type="checkbox" class="gd-checkbox" [checked]="allItemsSelected()"
+      <input type="checkbox" [disabled]="!(this.files && this.files.length > 0)" class="gd-checkbox" [checked]="allItemsSelected()"
                (change)="selectAllItems($event.target.checked);">
     </div>
     <div class="context">

--- a/libs/conversion/src/lib/conversion-browse-files-modal/conversion-browse-files-modal.component.ts
+++ b/libs/conversion/src/lib/conversion-browse-files-modal/conversion-browse-files-modal.component.ts
@@ -28,10 +28,6 @@ export class ConversionBrowseFilesModalComponent extends BrowseFilesModalCompone
     super(_uploadService);
   }
 
-  selectDD(entry){
-    console.log('SELECTED DD',entry);
-  }
-
   selectAllItems(checked: boolean){
     this.selectAll.emit(checked);
 
@@ -49,14 +45,15 @@ export class ConversionBrowseFilesModalComponent extends BrowseFilesModalCompone
   }
 
   getLabelString(){
+    const label = 'Add selected'
+
     if (this.files && this.files.length > 0) {
       const selectedCount = this.files.filter(file => file.selected).length;
-      if (selectedCount > 0) {
-      return 'Add ' + selectedCount + ' selected'
-      }
-      else {
-        return 'Add selected'
-      }
+      return selectedCount > 0 ? 'Add ' + selectedCount + ' selected' : label;
+    }
+    else
+    {
+      return label;
     }
   }
 

--- a/libs/conversion/src/lib/conversion-queue/conversion-queue.component.html
+++ b/libs/conversion/src/lib/conversion-queue/conversion-queue.component.html
@@ -7,7 +7,9 @@
     <div>Target</div>
     <div class="gd-queue-last-placeholder"></div>
   </div>
-  <div *ngFor="let item of items">
-      <gd-conversion-item [item]="item"></gd-conversion-item>
+  <div class="gd-queue-body">
+    <div *ngFor="let item of items">
+        <gd-conversion-item [item]="item"></gd-conversion-item>
+    </div>
   </div>
 </div>

--- a/libs/conversion/src/lib/conversion-queue/conversion-queue.component.less
+++ b/libs/conversion/src/lib/conversion-queue/conversion-queue.component.less
@@ -1,50 +1,55 @@
 @import "../../../../common-components/src/styles/variables";
 
 #gd-convert-queue {
-flex-direction: column;
-height: 100%;
-background-color: @mercury;
+    flex-direction  : column;
+    height          : 100%;
+    background-color: @mercury;
 }
 
 .gd-queue-header {
-display: flex;
-font-size: 13px;
-text-transform: uppercase;
-color: @dove-gray;
-width: 100%;
-height: 60px;
-background-color: @wild-sand;
-font-weight: bold;
-align-items: center;
+    display         : flex;
+    font-size       : 13px;
+    text-transform  : uppercase;
+    color           : @dove-gray;
+    width           : 100%;
+    height          : 60px;
+    background-color: @wild-sand;
+    font-weight     : bold;
+    align-items     : center;
 }
 
 .gd-placeholder {
-margin: 0px 42px 0 42px;
+    margin: 0px 42px 0 42px;
 }
 
 .gd-queue-header div:nth-child(2) {
-width: 671px;
-text-align: left;
-display: flex;
+    width     : 671px;
+    text-align: left;
+    display   : flex;
 }
 
 .gd-queue-header div:nth-child(4) {
-margin: 0 162px 0 111px;
-width: 32px;
+    margin: 0 162px 0 111px;
+    width : 32px;
 }
 
 .gd-queue-header div:nth-child(3) {
-width: 112px;
-text-align: left;
+    width     : 112px;
+    text-align: left;
 }
 
-.gd-queue-header div:nth-child(5){
-width: 644px;
-text-align: left;
+.gd-queue-header div:nth-child(5) {
+    width     : 644px;
+    text-align: left;
 }
 
-.gd-queue-last-placeholder{
-margin: 0px 52px;
+.gd-queue-body {
+    overflow-y: scroll;
+    height    : calc(100% - 120px);
+}
+
+.gd-queue-last-placeholder {
+    margin: 0px 52px;
 }
 
 @media @phone-down {

--- a/libs/conversion/src/lib/conversion.service.ts
+++ b/libs/conversion/src/lib/conversion.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpClient} from "@angular/common/http";
 import {
-  Api, ConfigService, FileCredentials, SaveFile, FileModel
+  Api, ConfigService, FileCredentials, SaveFile, FileModel, FileUtil
 } from "@groupdocs.examples.angular/common-components";
 import {Observable, BehaviorSubject, Observer} from "rxjs";
 import { ConversionItemModel, ConversionRequestModel } from './models';
@@ -62,6 +62,7 @@ export class ConversionService {
     req.destinationType = file.destinationType;
     req.guid = file.guid;
     req.size = file.size;
+    req.destDocumentType = FileUtil.find(file.destinationType, false).format;
     return this._http.post(this._config.getConversionApiEndpoint() + Api.CONVERT_FILE, req);
   }
 

--- a/libs/conversion/src/lib/models.ts
+++ b/libs/conversion/src/lib/models.ts
@@ -5,6 +5,7 @@ export class ConversionRequestModel{
   destinationType: string;
   guid: string;
   size: number;
+  destDocumentType: number;
 }
 
 export class ConversionItemModel implements FileModel {


### PR DESCRIPTION
- Improved filter for the conversion work-items, now it uses both source and destination formats;
- Checkbox `Select all` now disabled before uploading at least one file;
- `Add selected` button now has text label before uploading at least one file;
- Container with conversion work-items now has vertical scroll-bar;
- Conversion main component now sends destination document type (like `Microsoft Word`) to the server-side `Convert` method;
- E2E-tests were updated;