### PR TITLE
Excluded usage excel-document component in Image mode.

### DIFF
--- a/libs/viewer/src/lib/excel-document/excel-document.component.less
+++ b/libs/viewer/src/lib/excel-document/excel-document.component.less
@@ -78,6 +78,10 @@
   right: 0px;
 }
 
+.page-grid-lines {
+  background-color: white;
+}
+
 @media @phone-down {
   .document {
     overflow-x: auto !important;

--- a/libs/viewer/src/lib/viewer-app.component.html
+++ b/libs/viewer/src/lib/viewer-app.component.html
@@ -45,9 +45,9 @@
     <gd-thumbnails *ngIf="showThumbnails" [pages]="file.pages" [isHtmlMode]="htmlModeConfig"
                    [guid]="file.guid" [mode]="htmlModeConfig"></gd-thumbnails>
 
-    <gd-document class="gd-document" *ngIf="file && formatIcon !== 'file-excel'" [file]="file" [mode]="htmlModeConfig" gdScrollable
+    <gd-document class="gd-document" *ngIf="(file && formatIcon !== 'file-excel') || (formatIcon === 'file-excel' && !htmlModeConfig)" [file]="file" [mode]="htmlModeConfig" gdScrollable
                  [preloadPageCount]="viewerConfig?.preloadPageCount" gdRenderPrint [htmlMode]="htmlModeConfig"></gd-document>
-    <gd-excel-document class="gd-document" *ngIf="file && formatIcon === 'file-excel'" [file]="file" [mode]="htmlModeConfig" gdScrollable
+    <gd-excel-document class="gd-document" *ngIf="file && formatIcon === 'file-excel' && htmlModeConfig" [file]="file" [mode]="htmlModeConfig" gdScrollable
                  [preloadPageCount]="viewerConfig?.preloadPageCount" gdRenderPrint [htmlMode]="htmlModeConfig"></gd-excel-document>
   </div>
 


### PR DESCRIPTION
**Problem:**
In the image mode we can't calculate and render the column with line numbers and the row with column names basing on the html with Excel file content thus the UI code is falling.

**Solution:**
Were added conditions in the main Viewer app component for using the excel-document component only in the case of opening Excel files in the  html mode.