### PR TITLE
Added code for loading default doc if specified in Annotation config.

### DIFF
--- a/libs/annotation/src/lib/annotation-app.component.ts
+++ b/libs/annotation/src/lib/annotation-app.component.ts
@@ -285,6 +285,10 @@ export class AnnotationAppComponent implements OnInit {
   }
 
   ngOnInit() {
+    if (this.annotationConfig.defaultDocument !== ""){
+      this.isLoading = true;
+      this.selectFile(this.annotationConfig.defaultDocument, "", "");
+    }
   }
 
   private ptToPx(pt: number) {


### PR DESCRIPTION
**Problem:**
Loading the specified by _Absolute path_ default doc was missed in the Annotation app UI.

**Solution:**
Common code for such functionality was replicated from the Viewer app.

**Screenshots:**
<details>
  <summary>Take a look</summary>

![loading_default_doc](https://user-images.githubusercontent.com/17431807/91966060-06f6ed80-ed1a-11ea-8b67-629eb9ab1885.gif)

</details>