### PR TITLE
Fix for error on Excel opening.

### DIFF
--- a/libs/viewer/src/lib/excel-document/excel-document.component.ts
+++ b/libs/viewer/src/lib/excel-document/excel-document.component.ts
@@ -35,7 +35,9 @@ export class ExcelDocumentComponent extends DocumentComponent implements OnInit,
 
     this.navigateService.navigate.subscribe(((
      value => {
+       if (value) {
          this.selectSheet(value);
+       }
      })));
   }
 


### PR DESCRIPTION
**Problem:**
We've got error `Expression has changed after it was checked` on opening Excel file after latest changes.

**Solution:**
We don't switch to sheet if it's number is undefined.