### PR TITLE
Possible fixes for calculating slides zoom and top-margin in Opera and Safari respectively.

### DIFF
--- a/libs/viewer/src/lib/excel-document/excel-document.component.html
+++ b/libs/viewer/src/lib/excel-document/excel-document.component.html
@@ -11,7 +11,7 @@
 <div class="sheets">
   <div class="sheets-wrapper">
     <div *ngFor="let page of file?.pages">
-      <gd-button [icon]="'eye'" [ngClass]="{'active': currentPageNo == page.number }" (click)="selectSheet(page.number)">Sheet {{page.number}}</gd-button>
+      <gd-button [icon]="'eye'" [ngClass]="{'active': currentPageNo == page.number }" (click)="selectSheet(page.number)">{{page.sheetName}}</gd-button>
     </div>
   </div>
 </div>

--- a/libs/viewer/src/lib/run-presentation/run-presentation.component.ts
+++ b/libs/viewer/src/lib/run-presentation/run-presentation.component.ts
@@ -84,7 +84,8 @@ export class RunPresentationComponent implements OnInit, AfterViewChecked, After
   alignVert(): void {
     const presentationElements = this._elementRef.nativeElement.querySelectorAll('.presentation');
     const zoom = this._zoomService.zoom/100;
-    presentationElements.forEach(element => (element as HTMLElement).style.marginTop = ((window.innerHeight - element.clientHeight*zoom - Constants.topbarWidth)/2)/zoom + "px");
+    presentationElements.forEach(element => (element as HTMLElement).style.marginTop = 
+      ((window.innerHeight - (element.clientHeight ? element.clientHeight : element.scrollHeight)*zoom - Constants.topbarWidth)/2)/zoom + "px");
   }
 
   ngAfterViewChecked(): void {

--- a/libs/viewer/src/lib/viewer-app.component.ts
+++ b/libs/viewer/src/lib/viewer-app.component.ts
@@ -682,7 +682,7 @@ export class ViewerAppComponent implements OnInit, AfterViewInit {
     this.runPresentation = !this.runPresentation;
 
     const intervalId = setInterval(() => {
-      if (screen.height === window.innerHeight) {
+      if (screen.height === window.innerHeight && screen.width === window.innerWidth) {
       this.zoomService.changeZoom(window.innerWidth / window.innerHeight < 1.7 && this._pageWidth / this._pageHeight > 1.7 
         ? this.getFitToWidth() : this.getFitToHeight());
         clearInterval(intervalId);


### PR DESCRIPTION
**Screenshots:**

_Added sheets names:_
![image](https://user-images.githubusercontent.com/17431807/97565042-9bb65880-19f6-11eb-9225-47699c581df0.png)