### PR TITLE
[WIP] Fixed slides switching by mouse wheel, slides fitted to width.

### DIFF
--- a/libs/viewer/src/lib/viewer-app.component.less
+++ b/libs/viewer/src/lib/viewer-app.component.less
@@ -176,6 +176,10 @@
   }
 }
 
+::ng-deep .gd-wrapper {
+  pointer-events: none;
+}
+
 @media (max-width: 1037px) {
 
   .mobile-hide,

--- a/libs/viewer/src/lib/viewer-app.component.ts
+++ b/libs/viewer/src/lib/viewer-app.component.ts
@@ -571,7 +571,7 @@ export class ViewerAppComponent implements OnInit, AfterViewInit {
   {
     this.startScrollTime = Date.now();
     if (this.ifPresentation() && this.selectedPageNumber !== 1) {
-      if (this.startScrollTime - this.endScrollTime > 500 ) {
+      if (this.startScrollTime - this.endScrollTime > 300 && this.vertScrollEnded(true)) {
         this.selectedPageNumber = this.selectedPageNumber - 1;
         this.endScrollTime = Date.now();
       }
@@ -582,7 +582,7 @@ export class ViewerAppComponent implements OnInit, AfterViewInit {
   {
     this.startScrollTime = Date.now();
     if (this.ifPresentation() && this.selectedPageNumber !== this.file.pages.length) {
-      if (this.startScrollTime - this.endScrollTime > 500 ) {
+      if (this.startScrollTime - this.endScrollTime > 300 && this.vertScrollEnded(false)) {
         this.startScrollTime = Date.now();
         if (this.file.pages[this.selectedPageNumber] && !this.file.pages[this.selectedPageNumber].data) {
           this.preloadPages(this.selectedPageNumber, this.selectedPageNumber + 1);
@@ -594,6 +594,15 @@ export class ViewerAppComponent implements OnInit, AfterViewInit {
         this.endScrollTime = Date.now();
       }
     }
+  }
+
+  vertScrollEnded(onTop: boolean) {
+    const gdDocument = document.getElementsByClassName('gd-document')[0] as HTMLElement;
+    if (onTop)
+    {
+      return gdDocument.scrollTop === 0;
+    }
+    else return gdDocument.offsetHeight + gdDocument.scrollTop >= gdDocument.scrollHeight;
   }
 
   private TryOpenFileByUrl(queryString: string) {


### PR DESCRIPTION
**What were done:**
1. Fixed multiple slides switching through bunch of consequenti ve mouse wheel events.
2. Presentations now get `FitToWidth` scale on opening by default.
3. Was returned possibility to scroll to top/bottom the slide before slide switching.

**Screenshots:**
<details>
<legend>Take a look:</legend>

![scrolling_before_slide_switching](https://user-images.githubusercontent.com/17431807/97862765-f31a3880-1d16-11eb-84e2-e4674cb966c0.gif)

</details>