### PR TITLE
Discard pointer events only for slides.

### DIFF
--- a/libs/viewer/src/lib/viewer-app.component.less
+++ b/libs/viewer/src/lib/viewer-app.component.less
@@ -181,7 +181,7 @@
   }
 }
 
-::ng-deep .gd-wrapper {
+::ng-deep .page.presentation .gd-wrapper {
   pointer-events: none;
 }
 


### PR DESCRIPTION
Fix for https://github.com/groupdocs-viewer/GroupDocs.Viewer-for-.NET-MVC/issues/61.
Related back-end changes: https://github.com/groupdocs-viewer/GroupDocs.Viewer-for-.NET-MVC/pull/77.