### PR TITLE
Fixed issue 'Cannot read property 'replace' of undefined'

### DIFF
--- a/libs/common-components/src/lib/page/page.component.ts
+++ b/libs/common-components/src/lib/page/page.component.ts
@@ -29,7 +29,7 @@ export class PageComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     // TODO: this is temporary needed to remove unneeded spaces and BOM symbol 
     // which leads to undesired spaces on the top of the docs pages
-    this.data = this.data !== null ? this.data.replace(/>\s+</g,'><')
+    this.data = (typeof this.data !== 'undefined') && this.data !== null ? this.data.replace(/>\s+</g,'><')
                                               .replace(/\uFEFF/g,"")
                                               .replace(/href="\/viewer/g, 'href="http://localhost:8080/viewer')
                                               .replace(/src="\/viewer/g, 'src="http://localhost:8080/viewer')

--- a/libs/viewer/src/lib/excel-page/excel-page.component.ts
+++ b/libs/viewer/src/lib/excel-page/excel-page.component.ts
@@ -30,7 +30,7 @@ export class ExcelPageComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     // TODO: this is temporary needed to remove unneeded spaces and BOM symbol 
     // which leads to undesired spaces on the top of the docs pages
-    this.data = this.data !== null ? this.data.replace(/>\s+</g,'><')
+    this.data = (typeof this.data !== 'undefined') && this.data !== null ? this.data.replace(/>\s+</g,'><')
                                               .replace(/\uFEFF/g,"")
                                               .replace(/href="\/viewer/g, 'href="http://localhost:8080/viewer')
                                               .replace(/src="\/viewer/g, 'src="http://localhost:8080/viewer')


### PR DESCRIPTION
This issue happens in image mode when the `this.data` is undefined the method `this.data.replace` fails.

```
DocumentComponent.html:7 ERROR TypeError: Cannot read property 'replace' of undefined
    at PageComponent.ngOnChanges (groupdocs.examples.angular-common-components.js:1883)
    at checkAndUpdateDirectiveInline (core.js:31906)
    at checkAndUpdateNodeInline (core.js:44367)
    at checkAndUpdateNode (core.js:44306)
    at debugCheckAndUpdateNode (core.js:45328)
    at debugCheckDirectivesFn (core.js:45271)
    at Object.eval [as updateDirectives] (DocumentComponent.html:7)
    at Object.debugUpdateDirectives [as updateDirectives] (core.js:45259)
    at checkAndUpdateView (core.js:44271)
    at callViewAction (core.js:44637)
```