### PR TITLE
Add button to toggle annotations visibility on UI.

### DIFF
--- a/libs/annotation/src/lib/annotation-app.component.html
+++ b/libs/annotation/src/lib/annotation-app.component.html
@@ -15,7 +15,7 @@
               (click)="zoomIn()" *ngIf="zoomConfig"></gd-button>
             <gd-button class="desktop-hide" [disabled]="formatDisabled" [icon]="'search-minus'" [tooltip]="'Zoom Out'"
               (click)="zoomOut()" *ngIf="zoomConfig"></gd-button>
-            <gd-button [disabled]="formatDisabled" [icon]="'eye'" [tooltip]="'Hide annotations'" (click)="hideAnnotations()"></gd-button>
+            <gd-button [disabled]="formatDisabled" [icon]="annotationsHidden ? 'toggle-off' : 'toggle-on'" [tooltip]="'Hide annotations'" (click)="hideAnnotations()"></gd-button>
           </div>
         </gd-tab>
         <gd-tab [tabTitle]="'Annotations'" [icon]="'highlighter'" [id]="'2'"

--- a/libs/annotation/src/lib/annotation-app.component.html
+++ b/libs/annotation/src/lib/annotation-app.component.html
@@ -15,6 +15,7 @@
               (click)="zoomIn()" *ngIf="zoomConfig"></gd-button>
             <gd-button class="desktop-hide" [disabled]="formatDisabled" [icon]="'search-minus'" [tooltip]="'Zoom Out'"
               (click)="zoomOut()" *ngIf="zoomConfig"></gd-button>
+            <gd-button [disabled]="formatDisabled" [icon]="'eye'" [tooltip]="'Hide annotations'" (click)="hideAnnotations()"></gd-button>
           </div>
         </gd-tab>
         <gd-tab [tabTitle]="'Annotations'" [icon]="'highlighter'" [id]="'2'"

--- a/libs/annotation/src/lib/annotation-app.component.ts
+++ b/libs/annotation/src/lib/annotation-app.component.ts
@@ -90,6 +90,7 @@ export class AnnotationAppComponent implements OnInit {
   public annotations = new Map<number, ComponentRef<any>>();
   private creatingAnnotationId: number;
   private activeAnnotationId: number;
+  private annotationsHidden: boolean;
 
   constructor(private _annotationService: AnnotationService,
               private _modalService: ModalService,
@@ -355,6 +356,7 @@ export class AnnotationAppComponent implements OnInit {
         this.file = file;
         this.formatDisabled = !this.file;
         if (file) {
+          this.annotationsHidden = false;
           if (!this.isDesktop && file.pages && file.pages[0]) {
             this._pageHeight = file.pages[0].height;
             this._pageWidth = file.pages[0].width;
@@ -514,7 +516,7 @@ export class AnnotationAppComponent implements OnInit {
 
   hideAnnotations() {
     for (const annotationCompRef of this.annotations.values()) {
-      (<AnnotationComponent>annotationCompRef.instance).hidden = !(<AnnotationComponent>annotationCompRef.instance).hidden;
+      this.annotationsHidden = (<AnnotationComponent>annotationCompRef.instance).hidden = !(<AnnotationComponent>annotationCompRef.instance).hidden;
     }
   }
 

--- a/libs/annotation/src/lib/annotation-app.component.ts
+++ b/libs/annotation/src/lib/annotation-app.component.ts
@@ -512,7 +512,7 @@ export class AnnotationAppComponent implements OnInit {
     this.comments = new Map<number, Comment[]>();
   }
 
-  private hideAnnotations() {
+  hideAnnotations() {
     for (const annotationCompRef of this.annotations.values()) {
       (<AnnotationComponent>annotationCompRef.instance).hidden = !(<AnnotationComponent>annotationCompRef.instance).hidden;
     }

--- a/libs/annotation/src/lib/annotation-app.component.ts
+++ b/libs/annotation/src/lib/annotation-app.component.ts
@@ -90,7 +90,7 @@ export class AnnotationAppComponent implements OnInit {
   public annotations = new Map<number, ComponentRef<any>>();
   private creatingAnnotationId: number;
   private activeAnnotationId: number;
-  private annotationsHidden: boolean;
+  annotationsHidden: boolean;
 
   constructor(private _annotationService: AnnotationService,
               private _modalService: ModalService,

--- a/libs/annotation/src/lib/annotation-app.component.ts
+++ b/libs/annotation/src/lib/annotation-app.component.ts
@@ -512,6 +512,12 @@ export class AnnotationAppComponent implements OnInit {
     this.comments = new Map<number, Comment[]>();
   }
 
+  private hideAnnotations() {
+    for (const annotationCompRef of this.annotations.values()) {
+      (<AnnotationComponent>annotationCompRef.instance).hidden = !(<AnnotationComponent>annotationCompRef.instance).hidden;
+    }
+  }
+
   private clearData() {
     if (!this.file || !this.file.pages) {
       return;

--- a/libs/annotation/src/lib/annotation-app.component.ts
+++ b/libs/annotation/src/lib/annotation-app.component.ts
@@ -356,7 +356,6 @@ export class AnnotationAppComponent implements OnInit {
         this.file = file;
         this.formatDisabled = !this.file;
         if (file) {
-          this.annotationsHidden = false;
           if (!this.isDesktop && file.pages && file.pages[0]) {
             this._pageHeight = file.pages[0].height;
             this._pageWidth = file.pages[0].width;
@@ -590,6 +589,7 @@ export class AnnotationAppComponent implements OnInit {
       });
       (<AnnotationComponent>annotationComponent.instance).pageWidth = pageModel.width;
       (<AnnotationComponent>annotationComponent.instance).pageHeight = pageModel.height;
+      (<AnnotationComponent>annotationComponent.instance).hidden = this.annotationsHidden;
       this.annotations.set(id, annotationComponent);
       return id;
     }

--- a/libs/annotation/src/lib/annotation/annotation.component.html
+++ b/libs/annotation/src/lib/annotation/annotation.component.html
@@ -1,4 +1,4 @@
-<div class="gd-annotation"
+<div [hidden]="hidden" class="gd-annotation"
      (clickOutside)="hideMenu($event)"
      [exclude]="'gd-context-menu,.ui-resizable-handle,.gd-comments-panel'"
      [excludeBeforeClick]="true"
@@ -37,7 +37,7 @@
                [se]="true" [sw]="true" [ne]="true" [nw]="true"
                [pageHeight]="pageHeight" [pageWidth]="pageWidth"></gd-resizing>
 </div>
-<svg *ngIf="isSVG()" class="svg" xmlns="http://www.w3.org/2000/svg">
+<svg *ngIf="isSVG() && !hidden" class="svg" xmlns="http://www.w3.org/2000/svg">
   <polyline *ngIf="isPolyline()" [attr.id]="id" [attr.points]="pointsValue" [ngStyle]="setStyles()">
   </polyline>
   <path id="{{'gd-path-' + id}}" *ngIf="isPath()" [attr.d]="pathValue" [attr.marker-end]="bottom()"

--- a/libs/annotation/src/lib/annotation/annotation.component.ts
+++ b/libs/annotation/src/lib/annotation/annotation.component.ts
@@ -37,6 +37,7 @@ export class AnnotationComponent implements OnInit, AfterViewInit, AfterViewChec
   pointsValue = "";
   svgPath = "";
   formatting = Formatting.default();
+  hidden: boolean;
 
   private oldPosition: { x: number; y: number };
   private points = [];


### PR DESCRIPTION
- Added button to toggle visibility of the annotations UI components for already added to documents annotations.
- If annotations were hidden they still exists in the front-end data model so will be added/edited on the document.

**Screenshots:**
https://user-images.githubusercontent.com/17431807/115717556-f5368900-a382-11eb-9b62-7fa99d519b3b.gif

_Updated icon:_
![image](https://user-images.githubusercontent.com/17431807/115723309-85c39800-a388-11eb-8b8c-fbd914910c34.png)
![image](https://user-images.githubusercontent.com/17431807/115723367-95db7780-a388-11eb-8d91-1a803597da91.png)