### PR TITLE
[WIP] Remove localhost usages in Viewer module and related common-components.

### DIFF
--- a/libs/common-components/src/lib/page/page.component.ts
+++ b/libs/common-components/src/lib/page/page.component.ts
@@ -33,9 +33,6 @@ export class PageComponent implements OnInit, OnChanges {
       this.data = this.data 
         ? this.data.replace(/>\s+</g,'><')
         .replace(/\uFEFF/g,"")
-        .replace(/href="\/viewer/g, 'href="http://localhost:8080/viewer')
-        .replace(/src="\/viewer/g, 'src="http://localhost:8080/viewer')
-        .replace(/data="\/viewer/g, 'data="http://localhost:8080/viewer')
       : null;
     } else {
       this.imgData = 'data:image/png;base64,' + this.data;

--- a/libs/viewer/src/lib/excel-page/excel-page.component.ts
+++ b/libs/viewer/src/lib/excel-page/excel-page.component.ts
@@ -34,9 +34,6 @@ export class ExcelPageComponent implements OnInit, OnChanges {
       this.data = this.data 
         ? this.data.replace(/>\s+</g,'><')
         .replace(/\uFEFF/g,"")
-        .replace(/href="\/viewer/g, 'href="http://localhost:8080/viewer')
-        .replace(/src="\/viewer/g, 'src="http://localhost:8080/viewer')
-        .replace(/data="\/viewer/g, 'data="http://localhost:8080/viewer')
       : null;
     } else {
       this.imgData = 'data:image/png;base64,' + this.data;

--- a/libs/viewer/src/lib/thumbnails/thumbnails.component.ts
+++ b/libs/viewer/src/lib/thumbnails/thumbnails.component.ts
@@ -27,10 +27,7 @@ export class ThumbnailsComponent implements OnInit, OnChanges, AfterViewInit, On
       this.pages.forEach(page => {
         if (page.data) {
           page.data = page.data.replace(/>\s+</g,'><')
-                               .replace(/\uFEFF/g,"")
-                               .replace(/href="\/viewer/g, 'href="http://localhost:8080/viewer')
-                               .replace(/src="\/viewer/g, 'src="http://localhost:8080/viewer')
-                               .replace(/data="\/viewer/g, 'data="http://localhost:8080/viewer');
+                               .replace(/\uFEFF/g,"");
         }
       });
     }

--- a/libs/viewer/src/lib/viewer-app.component.ts
+++ b/libs/viewer/src/lib/viewer-app.component.ts
@@ -310,10 +310,7 @@ export class ViewerAppComponent implements OnInit, AfterViewInit {
         if (this.ifPresentation() && this.file.thumbnails && !this.file.thumbnails[i - 1].data) {
           if (page.data) {
             page.data = page.data.replace(/>\s+</g, '><')
-              .replace(/\uFEFF/g, "")
-              .replace(/href="\/viewer/g, 'href="http://localhost:8080/viewer')
-              .replace(/src="\/viewer/g, 'src="http://localhost:8080/viewer')
-              .replace(/data="\/viewer/g, 'data="http://localhost:8080/viewer');
+              .replace(/\uFEFF/g, "");
           }
           this.file.thumbnails[i - 1].data = page.data;
         }
@@ -459,10 +456,7 @@ export class ViewerAppComponent implements OnInit, AfterViewInit {
     if (this.saveRotateStateConfig && this.file) {
       this._viewerService.rotate(this.credentials, deg, pageNumber).subscribe((page: PageModel) => {
         const updatedData = page.data.replace(/>\s+</g,'><')
-          .replace(/\uFEFF/g,"")
-          .replace(/href="\/viewer/g, 'href="http://localhost:8080/viewer')
-          .replace(/src="\/viewer/g, 'src="http://localhost:8080/viewer')
-          .replace(/data="\/viewer/g, 'data="http://localhost:8080/viewer');
+          .replace(/\uFEFF/g,"");
         page.data = updatedData;
         this.file.pages[pageNumber - 1] = page;
 

--- a/libs/viewer/src/lib/viewer.module.ts
+++ b/libs/viewer/src/lib/viewer.module.ts
@@ -22,12 +22,6 @@ export function initializeApp(viewerConfigService: ViewerConfigService) {
   return result;
 }
 
-export function endPoint() {
-  const config = new ConfigService();
-  config.apiEndpoint = "http://localhost:8080";
-  return config;
-}
-
 // NOTE: this is required during library compilation see https://github.com/angular/angular/issues/23629#issuecomment-440942981
 // @dynamic
 export function setupLoadingInterceptor(service: LoadingMaskService) {
@@ -57,10 +51,7 @@ export function setupLoadingInterceptor(service: LoadingMaskService) {
   ],
   providers: [
     ViewerService,
-    {
-      provide: ConfigService,
-      useFactory: endPoint
-    },
+    ConfigService,
     ViewerConfigService,
     {
       provide: HTTP_INTERCEPTORS,


### PR DESCRIPTION
**Problem:**
We would like to support feature for using API URL different from default `localhost:8080` and we have step-by-step instruction here: https://products.conholdate.app/viewer/view/59mhVoboa6I5O4DL3/using-custom-host-url-step-by-step-guide.docx?preview=true.pdf.
But Viewer UI-package has an additional usage of the `localhost:8080` in it's module class declaration.

**Solution:**
- Usage of the `localhost:8080` was removed from the Viewer module class declaration.
- Additionally were removed usages of the `localhost:8080` from Viewer-app related common-components.

**Tests:**
- Running the Viewer-app (`.NET-WebForms`-backend) on localhost:8080 and on `random_ipv4:8080`.
- Opening files using general case with upload and using query-string parameter.

Related PR: https://github.com/groupdocs-viewer/GroupDocs.Viewer-for-.NET-WebForms/pull/84