### PR TITLE
Viewer not working when a query string parameter is specified

### DIFF
--- a/libs/common-components/src/lib/config.service.ts
+++ b/libs/common-components/src/lib/config.service.ts
@@ -10,7 +10,7 @@ export class Api {
   public static COMPARISON_APP = '/comparison';
   public static CONVERSION_APP = '/conversion';
   public static METADATA_APP = '/metadata';
-  public static DEFAULT_API_ENDPOINT = window.location.href;
+  public static DEFAULT_API_ENDPOINT = window.location.protocol + "//" + window.location.host + window.location.pathname;
   public static LOAD_FILE_TREE = '/loadFileTree';
   public static LOAD_CONFIG = '/loadConfig';
   public static LOAD_DOCUMENT_DESCRIPTION = '/loadDocumentDescription';


### PR DESCRIPTION
In case you specify query string parameter e.g. `?file=sample.docx` Viewer fails to open because of config service that is not stripping query but using `window.location.href`.