### PR TITLE
Fix thumbnails rendering in image mode

### DIFF
--- a/libs/viewer/src/lib/thumbnails/thumbnails.component.html
+++ b/libs/viewer/src/lib/thumbnails/thumbnails.component.html
@@ -17,6 +17,13 @@
            <img style="width: inherit !important" class="gd-page-image" [attr.src]="imgData(page.data) | safeResourceHtml"
              alt/>
       </div>
+      <div class="gd-wrapper"
+           [style.height]="getDimensionWithUnit(800)"
+           [style.width]="getDimensionWithUnit(800)"
+           [ngStyle]="{'transform': 'translateX(-50%) translateY(-50%) scale('+getScale(800, 800)+')'}"
+           *ngIf="!page.data"
+           [innerHTML]="emptyThumbData(page.number) | safeHtml">
+      </div>
     </div>
   </div>
 </div>

--- a/libs/viewer/src/lib/thumbnails/thumbnails.component.ts
+++ b/libs/viewer/src/lib/thumbnails/thumbnails.component.ts
@@ -65,4 +65,8 @@ export class ThumbnailsComponent implements OnInit, OnChanges, AfterViewInit, On
   getDimensionWithUnit(value: number) {
     return value + FileUtil.find(this.guid, false).unit;
   }
+
+  emptyThumbData(pageNumber: number) {
+    return `<div style="height:100%;display:grid;color:#bfbfbf"><div style="font-size:10vw;margin:auto;text-align:center;">${pageNumber}</div></div>`
+  }
 }

--- a/libs/viewer/src/lib/viewer-app.component.ts
+++ b/libs/viewer/src/lib/viewer-app.component.ts
@@ -346,25 +346,6 @@ export class ViewerAppComponent implements OnInit, AfterViewInit {
     return preloadPageCount;
   }
 
-  copyThumbnails(pages: PageModel[]) {
-    const thumbnails = pages.slice();
-
-    for (let thumbIndex = 0; thumbIndex < thumbnails.length; thumbIndex++) {
-      const thumb = thumbnails[thumbIndex];
-      if(!thumb.data) {
-        const emptyThumb = new PageModel();
-        emptyThumb.number = thumb.number;
-        emptyThumb.data = `<div style="height:100%;display:grid;color:#bfbfbf"><div style="font-size:10vw;margin:auto;text-align:center;">${thumb.number}</div></div>`
-        emptyThumb.width = 800;
-        emptyThumb.height = 800;
-        
-        thumbnails[thumbIndex] = emptyThumb;
-      }
-    }
-
-    return thumbnails;
-  }
-
   selectFile($event: string, password: string, modalId: string) {
     this.credentials = {guid: $event, password: password};
     this.file = null;
@@ -386,7 +367,7 @@ export class ViewerAppComponent implements OnInit, AfterViewInit {
           const countPages = file.pages ? file.pages.length : 0;
 
           if (preloadPageCount > 0) {
-            this.file.thumbnails = this.copyThumbnails(file.pages);
+            this.file.thumbnails = file.pages.slice();
             this.preloadPages(1, preloadPageCount > countPages ? countPages : preloadPageCount);
           }
 
@@ -419,9 +400,10 @@ export class ViewerAppComponent implements OnInit, AfterViewInit {
           page.data = page.data.replace(/>\s+</g, '><').replace(/\uFEFF/g, '');
         }
 
-        this.file.pages[pageNumber - 1] = page;
+        this.file.pages[pageNumber - 1].data = page.data;
+        
         if (this.file.thumbnails) {
-          this.file.thumbnails[pageNumber - 1] = page;
+          this.file.thumbnails[pageNumber - 1].data = page.data;
         }
       });
     }


### PR DESCRIPTION
In case when a thumbnail is missing e.g. page is not loaded we'll show an empty thumbnail with the page number.