### PR TITLE
Fixed viewer component pages preload when selecting new file

### DIFF
--- a/libs/viewer/src/lib/viewer-app.component.ts
+++ b/libs/viewer/src/lib/viewer-app.component.ts
@@ -121,10 +121,12 @@ export class ViewerAppComponent implements OnInit, AfterViewInit {
     });
 
     pagePreloadService.checkPreload.subscribe((page: number) => {
-      if (this.viewerConfig.preloadPageCount !== 0) {
-        for (let i = page; i < page + 2; i++) {
-          if (i > 0 && i <= this.countPages && !this.file.pages[i - 1].data) {
-            this.preloadPages(i, i);
+      if(this.file) {
+        if (this.viewerConfig.preloadPageCount !== 0) {
+          for (let i = page; i < page + 2; i++) {
+            if (i > 0 && i <= this.file.pages.length && !this.file.pages[i - 1].data) {
+              this.preloadPages(i, i);
+            }
           }
         }
       }


### PR DESCRIPTION
Fixed issue that lead to the following error in console
```
ERROR TypeError: Cannot read properties of null (reading 'pages')
```