### PR TITLE
Fixed up navigation in the file browser component.

### DIFF
--- a/libs/common-components/src/lib/browse-files-modal/browse-files-modal.component.ts
+++ b/libs/common-components/src/lib/browse-files-modal/browse-files-modal.component.ts
@@ -90,7 +90,7 @@ export class BrowseFilesModalComponent implements OnInit {
         guid = guid.replace(/\/[^\/]+\/?$/, '');
       }
 
-      var prevDir = new FileModel();
+      const prevDir = new FileModel();
       prevDir.name = guid;
       prevDir.guid = guid;
       prevDir.directory = true;

--- a/libs/common-components/src/lib/browse-files-modal/browse-files-modal.component.ts
+++ b/libs/common-components/src/lib/browse-files-modal/browse-files-modal.component.ts
@@ -89,6 +89,14 @@ export class BrowseFilesModalComponent implements OnInit {
       } else {
         guid = guid.replace(/\/[^\/]+\/?$/, '');
       }
+
+      var prevDir = new FileModel();
+      prevDir.name = guid;
+      prevDir.guid = guid;
+      prevDir.directory = true;
+      prevDir.isDirectory = true;
+      
+      this.selectedFile = prevDir;
       this.selectedDirectory.emit(guid);
     }
   }


### PR DESCRIPTION
This change fixes the issue when you can't navigate up to the previous folder when in case there are more than two folders. For example, if you navigate to `\folder-a\folder-b\`  you can't navigate back to the root folder.  