### PR TITLE
Fixed overlapping issues when viewing Excel spreadsheets in HTML mode

### DIFF
--- a/libs/viewer/src/lib/excel-page/excel-page.component.less
+++ b/libs/viewer/src/lib/excel-page/excel-page.component.less
@@ -22,25 +22,7 @@
   background-color: #ff9b00;
 }
 
-::ng-deep th {
-  color           : @regent-gray;
-  background-color: @wild-sand;
-  font-weight     : unset;
-  border          : 1px solid @mercury  !important;
-  text-transform  : uppercase;
-  font-size       : 14px;
-  overflow        : hidden;
-}
-
-::ng-deep td {
-  vertical-align: middle !important;
-}
-
 ::ng-deep .page-grid-lines td {
-  border: 1px solid @mercury  !important;
-}
-
-::ng-deep .page td:nth-child(1) {
   border: 1px solid @mercury  !important;
 }
 


### PR DESCRIPTION
This change fixes the issue caused by the global styles that are applied to all spreadsheets that are rendered to HTML. The global styles have been removed.